### PR TITLE
Improve tps and other fixes

### DIFF
--- a/common/src/main/java/net/impleri/playerskills/integration/kubejs/api/AbstractRegistrationEventJS.java
+++ b/common/src/main/java/net/impleri/playerskills/integration/kubejs/api/AbstractRegistrationEventJS.java
@@ -13,6 +13,7 @@ import net.minecraft.tags.TagKey;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -57,8 +58,8 @@ abstract public class AbstractRegistrationEventJS<T, R extends AbstractRestricti
     }
 
     @HideFromJS
-    private String appendListInfo(List<ResourceLocation> list, String description) {
-        return list.isEmpty() ? "" : description + " " + list;
+    private String appendListInfo(Set<ResourceLocation> set, String description) {
+        return set.isEmpty() ? "" : description + " " + set;
     }
 
     @HideFromJS

--- a/common/src/main/java/net/impleri/playerskills/restrictions/AbstractRestriction.java
+++ b/common/src/main/java/net/impleri/playerskills/restrictions/AbstractRestriction.java
@@ -5,9 +5,9 @@ import net.minecraft.world.entity.player.Player;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public abstract class AbstractRestriction<Target> {
     private static final Predicate<Player> DEFAULT_CONDITION = (Player player) -> true;
@@ -16,11 +16,11 @@ public abstract class AbstractRestriction<Target> {
 
     public final @NotNull Predicate<Player> condition;
 
-    public final List<ResourceLocation> includeDimensions;
-    public final List<ResourceLocation> excludeDimensions;
+    public final Set<ResourceLocation> includeDimensions;
+    public final Set<ResourceLocation> excludeDimensions;
 
-    public final List<ResourceLocation> includeBiomes;
-    public final List<ResourceLocation> excludeBiomes;
+    public final Set<ResourceLocation> includeBiomes;
+    public final Set<ResourceLocation> excludeBiomes;
 
 
     public AbstractRestriction(
@@ -35,10 +35,10 @@ public abstract class AbstractRestriction<Target> {
         this.target = target;
         this.replacement = replacement;
         this.condition = (condition != null) ? condition : DEFAULT_CONDITION;
-        this.includeDimensions = (includeDimensions != null) ? includeDimensions : new ArrayList<>();
-        this.excludeDimensions = (excludeDimensions != null) ? excludeDimensions : new ArrayList<>();
-        this.includeBiomes = (includeBiomes != null) ? includeBiomes : new ArrayList<>();
-        this.excludeBiomes = (excludeBiomes != null) ? excludeBiomes : new ArrayList<>();
+        this.includeDimensions = Optional.ofNullable(includeDimensions).map(HashSet::new).orElseGet(HashSet::new);
+        this.excludeDimensions = Optional.ofNullable(excludeDimensions).map(HashSet::new).orElseGet(HashSet::new);
+        this.includeBiomes = Optional.ofNullable(includeBiomes).map(HashSet::new).orElseGet(HashSet::new);
+        this.excludeBiomes = Optional.ofNullable(excludeBiomes).map(HashSet::new).orElseGet(HashSet::new);
     }
 
     public AbstractRestriction(


### PR DESCRIPTION
1. Remove possible memory leak due to storing Player ref as a map key
2. Speed up search in restriction collections by changing them to Sets